### PR TITLE
change `arch` to `uname -m` for better use

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -62,7 +62,7 @@ _wget() {
 cmd=$(type -P apt-get || type -P yum || type -P zypper)
 
 # x64
-case $(arch) in
+case $(uname -m) in
 amd64 | x86_64)
     is_arch="amd64"
     ;;


### PR DESCRIPTION
对于 archlinux 来说，`arch` 命令一般不会被启用，从通用性角度考虑，使用 `uname -m` 来替换 `arch` 命令可能会更好一点？