### PR TITLE
feat: add Alpine Linux (OpenRC) support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,13 +34,15 @@ warn() {
 # root
 [[ $EUID != 0 ]] && err "当前非 ${yellow}ROOT用户.${none}"
 
-# apt-get, yum or zypper, ubuntu/debian/centos/suse
-cmd=$(type -P apt-get || type -P yum || type -P zypper)
-[[ ! $cmd ]] && err "此脚本仅支持 ${yellow}(Ubuntu or Debian or CentOS or SUSE)${none}."
+# apt-get, yum, zypper or apk
+cmd=$(type -P apt-get || type -P yum || type -P zypper || type -P apk)
+[[ ! $cmd ]] && err "此脚本仅支持 ${yellow}(Ubuntu or Debian or CentOS or SUSE or Alpine)${none}."
 
-# systemd
-[[ ! $(type -P systemctl) ]] && {
-    err "此系统缺少 ${yellow}(systemctl)${none}, 请尝试执行:${yellow} ${cmd} update -y;${cmd} install systemd -y ${none}来修复此错误."
+# systemd or openrc
+is_systemd=$(type -P systemctl)
+is_openrc=$(type -P rc-service)
+[[ ! $is_systemd && ! $is_openrc ]] && {
+    err "此系统缺少 ${yellow}(systemctl 或 rc-service)${none}, 请安装 systemd 或确认 OpenRC 已启用."
 }
 
 # wget installed or none
@@ -69,7 +71,7 @@ is_log_dir=/var/log/$is_core
 is_sh_bin=/usr/local/bin/$is_core
 is_sh_dir=$is_core_dir/sh
 is_sh_repo=$author/$is_core
-is_pkg="wget tar"
+is_pkg="wget tar bash"
 is_config_json=$is_core_dir/config.json
 tmp_var_lists=(
     tmpcore
@@ -141,19 +143,22 @@ install_pkg() {
     if [[ $cmd_not_found ]]; then
         pkg=$(echo $cmd_not_found | sed 's/,/ /g')
         msg warn "安装依赖包 >${pkg}"
-        $cmd install -y $pkg &>/dev/null
-        if [[ $? != 0 ]]; then
-            [[ $cmd =~ yum ]] && yum install epel-release -y &>/dev/null
-            if [[ $cmd =~ zypper ]]; then
-                $cmd --non-interactive refresh &>/dev/null
-            else
-                $cmd update -y &>/dev/null
-            fi
-            $cmd install -y $pkg &>/dev/null
-            [[ $? == 0 ]] && >$is_pkg_ok
+        if [[ $cmd =~ apk ]]; then
+            apk update &>/dev/null
+            apk add $pkg &>/dev/null
         else
-            >$is_pkg_ok
+            $cmd install -y $pkg &>/dev/null
+            if [[ $? != 0 ]]; then
+                [[ $cmd =~ yum ]] && yum install epel-release -y &>/dev/null
+                if [[ $cmd =~ zypper ]]; then
+                    $cmd --non-interactive refresh &>/dev/null
+                else
+                    $cmd update -y &>/dev/null
+                fi
+                $cmd install -y $pkg &>/dev/null
+            fi
         fi
+        [[ $? == 0 ]] && >$is_pkg_ok
     else
         >$is_pkg_ok
     fi
@@ -333,10 +338,12 @@ main() {
         msg warn "${yellow}本地获取安装脚本 > $PWD ${none}"
     }
 
-    timedatectl set-ntp true &>/dev/null
-    [[ $? != 0 ]] && {
-        is_ntp_on=1
-    }
+    if [[ $is_systemd ]]; then
+        timedatectl set-ntp true &>/dev/null
+        [[ $? != 0 ]] && {
+            is_ntp_on=1
+        }
+    fi
 
     # install dependent pkg
     install_pkg $is_pkg &
@@ -346,6 +353,10 @@ main() {
         >$is_jq_ok
     else
         jq_not_found=1
+        # Alpine: install jq via apk instead of downloading glibc binary
+        [[ $cmd =~ apk ]] && {
+            apk add jq &>/dev/null && jq_not_found= && >$is_jq_ok
+        }
     fi
     # if wget installed. download core, sh, jq, get ip
     [[ $is_wget ]] && {
@@ -420,7 +431,7 @@ main() {
     # show a tips msg
     msg ok "生成配置文件..."
 
-    # create systemd service
+    # create service
     load systemd.sh
     is_new_install=1
     install_service $is_core &>/dev/null

--- a/install.sh
+++ b/install.sh
@@ -209,7 +209,11 @@ check_status() {
     # dependent pkg install fail
     [[ ! -f $is_pkg_ok ]] && {
         msg err "安装依赖包失败"
-        msg err "请尝试手动安装依赖包: $cmd update -y; $cmd install -y $is_pkg"
+        if [[ $cmd =~ apk ]]; then
+            msg err "请尝试手动安装依赖包: apk update; apk add $is_pkg"
+        else
+            msg err "请尝试手动安装依赖包: $cmd update -y; $cmd install -y $is_pkg"
+        fi
         is_fail=1
     }
 

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,8 @@ is_sh_bin=/usr/local/bin/$is_core
 is_sh_dir=$is_core_dir/sh
 is_sh_repo=$author/$is_core
 is_pkg="wget tar bash"
+# Alpine: gcompat provides glibc compatibility for prebuilt binaries
+[[ $cmd =~ apk ]] && is_pkg="$is_pkg gcompat"
 is_config_json=$is_core_dir/config.json
 tmp_var_lists=(
     tmpcore

--- a/src/core.sh
+++ b/src/core.sh
@@ -92,6 +92,20 @@ servername_list=(
     aws.amazon.com
 )
 
+# shuf fallback for systems without shuf (e.g., Alpine BusyBox)
+if ! type -P shuf &>/dev/null; then
+    shuf() {
+        local min max n
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+            -i) IFS=- read min max <<<"$2"; shift 2 ;;
+            -n) n=$2; shift 2 ;;
+            esac
+        done
+        echo $(( RANDOM % (max - min + 1) + min ))
+    }
+fi
+
 is_random_ss_method=${ss_method_list[$(shuf -i 4-6 -n1)]} # random only use ss2022
 is_random_servername=${servername_list[$(shuf -i 0-${#servername_list[@]} -n1) - 1]}
 
@@ -679,13 +693,22 @@ uninstall() {
     fi
     manage stop &>/dev/null
     manage disable &>/dev/null
-    rm -rf $is_core_dir $is_log_dir $is_sh_bin ${is_sh_bin/$is_core/sb} /lib/systemd/system/$is_core.service
+    rm -rf $is_core_dir $is_log_dir $is_sh_bin ${is_sh_bin/$is_core/sb}
+    if [[ $is_systemd ]]; then
+        rm -f /lib/systemd/system/$is_core.service
+    elif [[ $is_openrc ]]; then
+        rm -f /etc/init.d/$is_core
+    fi
     sed -i "/$is_core/d" /root/.bashrc
     # uninstall caddy; 2 is ask result
     if [[ $REPLY == '2' ]]; then
         manage stop caddy &>/dev/null
         manage disable caddy &>/dev/null
-        rm -rf $is_caddy_dir $is_caddy_bin /lib/systemd/system/caddy.service
+        if [[ $is_systemd ]]; then
+            rm -rf $is_caddy_dir $is_caddy_bin /lib/systemd/system/caddy.service
+        elif [[ $is_openrc ]]; then
+            rm -rf $is_caddy_dir $is_caddy_bin /etc/init.d/caddy
+        fi
     fi
     [[ $is_install_sh ]] && return # reinstall
     _green "\n卸载完成!"
@@ -728,10 +751,24 @@ manage() {
         is_do_name_msg=$is_core_name
         ;;
     esac
-    systemctl $is_do $is_do_name
+    if [[ $is_systemd ]]; then
+        systemctl $is_do $is_do_name 2>/dev/null
+    elif [[ $is_openrc ]]; then
+        case $is_do in
+        enable)
+            rc-update add $is_do_name default 2>/dev/null
+            ;;
+        disable)
+            rc-update del $is_do_name default 2>/dev/null
+            ;;
+        *)
+            rc-service $is_do_name $is_do 2>/dev/null
+            ;;
+        esac
+    fi
     [[ $is_test_run && ! $is_new_install ]] && {
         sleep 2
-        if [[ ! $(pgrep -f $is_run_bin) ]]; then
+        if [[ ! $(pgrep -f $is_run_bin 2>/dev/null || grep -l "$is_run_bin" /proc/*/cmdline 2>/dev/null) ]]; then
             is_run_fail=${is_do_name_msg,,}
             [[ ! $is_no_manage_msg ]] && {
                 msg
@@ -1228,13 +1265,15 @@ get() {
         bash <<<$is_install_sh
         ;;
     test-run)
-        systemctl list-units --full -all &>/dev/null
-        [[ $? != 0 ]] && {
-            _yellow "\n无法执行测试, 请检查 systemctl 状态.\n"
-            return
-        }
+        if [[ $is_systemd ]]; then
+            systemctl list-units --full -all &>/dev/null
+            [[ $? != 0 ]] && {
+                _yellow "\n无法执行测试, 请检查 systemctl 状态.\n"
+                return
+            }
+        fi
         is_no_manage_msg=1
-        if [[ ! $(pgrep -f $is_core_bin) ]]; then
+        if [[ ! $(pgrep -f $is_core_bin 2>/dev/null || grep -l "$is_core_bin" /proc/*/cmdline 2>/dev/null) ]]; then
             _yellow "\n测试运行 $is_core_name ..\n"
             manage start &>/dev/null
             if [[ $is_run_fail == $is_core ]]; then
@@ -1247,7 +1286,7 @@ get() {
             _green "\n$is_core_name 正在运行, 跳过测试\n"
         fi
         if [[ $is_caddy ]]; then
-            if [[ ! $(pgrep -f $is_caddy_bin) ]]; then
+            if [[ ! $(pgrep -f $is_caddy_bin 2>/dev/null || grep -l "$is_caddy_bin" /proc/*/cmdline 2>/dev/null) ]]; then
                 _yellow "\n测试运行 Caddy ..\n"
                 manage start caddy &>/dev/null
                 if [[ $is_run_fail == 'caddy' ]]; then

--- a/src/init.sh
+++ b/src/init.sh
@@ -58,8 +58,8 @@ _wget() {
     wget --no-check-certificate "$@"
 }
 
-# apt-get, yum or zypper
-cmd=$(type -P apt-get || type -P yum || type -P zypper)
+# apt-get, yum, zypper or apk
+cmd=$(type -P apt-get || type -P yum || type -P zypper || type -P apk)
 
 # x64
 case $(uname -m) in
@@ -84,14 +84,20 @@ is_log_dir=/var/log/$is_core
 is_sh_bin=/usr/local/bin/$is_core
 is_sh_dir=$is_core_dir/sh
 is_sh_repo=$author/$is_core
-is_pkg="wget unzip tar qrencode"
+is_pkg="wget unzip tar qrencode bash"
 is_config_json=$is_core_dir/config.json
 is_caddy_bin=/usr/local/bin/caddy
 is_caddy_dir=/etc/caddy
 is_caddy_repo=caddyserver/caddy
 is_caddyfile=$is_caddy_dir/Caddyfile
 is_caddy_conf=$is_caddy_dir/$author
-is_caddy_service=$(systemctl list-units --full -all | grep caddy.service)
+is_systemd=$(type -P systemctl)
+is_openrc=$(type -P rc-service)
+if [[ $is_systemd ]]; then
+    is_caddy_service=$(systemctl list-units --full -all | grep caddy.service)
+elif [[ $is_openrc ]]; then
+    [[ -f /etc/init.d/caddy ]] && is_caddy_service=1
+fi
 is_http_port=80
 is_https_port=443
 
@@ -109,7 +115,7 @@ is_tls_key=$is_core_dir/bin/tls.key
     rm $is_tls_tmp
 }
 
-if [[ $(pgrep -f $is_core_bin) ]]; then
+if [[ $(pgrep -f $is_core_bin 2>/dev/null || grep -l "$is_core_bin" /proc/*/cmdline 2>/dev/null) ]]; then
     is_core_status=$(_green running)
 else
     is_core_status=$(_red_bg stopped)
@@ -117,18 +123,19 @@ else
 fi
 if [[ -f $is_caddy_bin && -d $is_caddy_dir && $is_caddy_service ]]; then
     is_caddy=1
-    # fix caddy run; ver >= 2.8.2
-    [[ ! $(grep '\-\-adapter caddyfile' /lib/systemd/system/caddy.service) ]] && {
-        load systemd.sh
-        install_service caddy
-        systemctl restart caddy &
-    }
+    if [[ $is_systemd ]]; then
+        [[ -f /lib/systemd/system/caddy.service && ! $(grep '\-\-adapter caddyfile' /lib/systemd/system/caddy.service) ]] && {
+            load systemd.sh
+            install_service caddy
+            systemctl restart caddy &
+        }
+    fi
     is_caddy_ver=$($is_caddy_bin version | head -n1 | cut -d " " -f1)
     is_tmp_http_port=$(grep -E '^ {2,}http_port|^http_port' $is_caddyfile | grep -E -o [0-9]+)
     is_tmp_https_port=$(grep -E '^ {2,}https_port|^https_port' $is_caddyfile | grep -E -o [0-9]+)
     [[ $is_tmp_http_port ]] && is_http_port=$is_tmp_http_port
     [[ $is_tmp_https_port ]] && is_https_port=$is_tmp_https_port
-    if [[ $(pgrep -f $is_caddy_bin) ]]; then
+    if [[ $(pgrep -f $is_caddy_bin 2>/dev/null || grep -l "$is_caddy_bin" /proc/*/cmdline 2>/dev/null) ]]; then
         is_caddy_status=$(_green running)
     else
         is_caddy_status=$(_red_bg stopped)

--- a/src/systemd.sh
+++ b/src/systemd.sh
@@ -77,12 +77,15 @@ install_service_openrc() {
 
 name="$is_core_name"
 description="$is_core_name Service"
+
 command="$is_core_bin"
 command_args="run -c $is_config_json -C $is_conf_dir"
 command_background=true
 pidfile="/run/\${RC_SVCNAME}.pid"
 output_log="/var/log/$is_core/access.log"
 error_log="/var/log/$is_core/error.log"
+
+supervisor=supervise-daemon
 
 depend() {
     need net
@@ -97,10 +100,13 @@ EOF
 
 name="Caddy"
 description="Caddy web server"
+
 command="$is_caddy_bin"
 command_args="run --environ --config $is_caddyfile --adapter caddyfile"
 command_background=true
 pidfile="/run/\${RC_SVCNAME}.pid"
+
+supervisor=supervise-daemon
 
 depend() {
     need net

--- a/src/systemd.sh
+++ b/src/systemd.sh
@@ -1,4 +1,16 @@
+# detect init system
+is_systemd=$(type -P systemctl)
+is_openrc=$(type -P rc-service)
+
 install_service() {
+    if [[ $is_systemd ]]; then
+        install_service_systemd $1
+    elif [[ $is_openrc ]]; then
+        install_service_openrc $1
+    fi
+}
+
+install_service_systemd() {
     case $1 in
     $is_core)
         is_doc_site=https://sing-box.sagernet.org/
@@ -55,4 +67,50 @@ WantedBy=multi-user.target"
     # enable, reload
     systemctl enable $1
     systemctl daemon-reload
+}
+
+install_service_openrc() {
+    case $1 in
+    $is_core)
+        cat >/etc/init.d/$is_core <<EOF
+#!/sbin/openrc-run
+
+name="$is_core_name"
+description="$is_core_name Service"
+command="$is_core_bin"
+command_args="run -c $is_config_json -C $is_conf_dir"
+command_background=true
+pidfile="/run/\${RC_SVCNAME}.pid"
+output_log="/var/log/$is_core/access.log"
+error_log="/var/log/$is_core/error.log"
+
+depend() {
+    need net
+    after firewall
+}
+EOF
+        chmod +x /etc/init.d/$is_core
+        ;;
+    caddy)
+        cat >/etc/init.d/caddy <<EOF
+#!/sbin/openrc-run
+
+name="Caddy"
+description="Caddy web server"
+command="$is_caddy_bin"
+command_args="run --environ --config $is_caddyfile --adapter caddyfile"
+command_background=true
+pidfile="/run/\${RC_SVCNAME}.pid"
+
+depend() {
+    need net
+    after firewall
+}
+EOF
+        chmod +x /etc/init.d/caddy
+        ;;
+    esac
+
+    # enable
+    rc-update add $1 default
 }


### PR DESCRIPTION
## Summary

Add Alpine Linux support (3.18+) while keeping all existing systemd functionality unchanged.

## Changes

- Add `apk` to package manager detection
- Support both systemd and OpenRC init systems; original systemd logic untouched
- Generate OpenRC init scripts (`/etc/init.d/`) with `supervise-daemon` for auto-restart on failure
- Adapt service management for OpenRC (`rc-service`, `rc-update`)
- Add `/proc` fallback for `pgrep` to support BusyBox environments
- Add `shuf` fallback function for systems without coreutils
- Install `gcompat` on Alpine for glibc binary compatibility
- Install jq via `apk add` on Alpine to avoid glibc binary incompatibility
- Run `timedatectl` only on systemd systems
- Correct error messages for Alpine package manager syntax

## Files Modified

- `install.sh`
- `src/init.sh`
- `src/systemd.sh`
- `src/core.sh`

No impact on existing Ubuntu/Debian/CentOS/SUSE installations.

## Testing

Tested on Alpine 3.21 (OpenRC) with `bash install.sh -l`:
- Install: OK
- sing-box start/status: OK
- Uninstall: OK
