### PR TITLE
fix: force full package install on Alpine and wait for service start

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -353,7 +353,10 @@ main() {
 
     # install dependent pkg
     if [[ $cmd =~ apk ]]; then
-        install_pkg $is_pkg
+        # Alpine: force install full versions to replace BusyBox applets
+        apk update &>/dev/null
+        apk add $is_pkg &>/dev/null
+        [[ $? == 0 ]] && >$is_pkg_ok
     else
         install_pkg $is_pkg &
     fi

--- a/install.sh
+++ b/install.sh
@@ -448,6 +448,8 @@ main() {
     load core.sh
     # create a reality config
     add reality
+    # wait for background tasks (e.g., OpenRC service start)
+    wait
     # remove tmp dir and exit.
     exit_and_del_tmpdir ok
 }


### PR DESCRIPTION
Two fixes for Alpine:

1. Force install full versions of wget/tar via apk add, bypassing type -P detection. BusyBox provides stripped-down versions that lack required flags (-4, -6 for wget), causing get_ip to fail.

2. Add wait before exit so OpenRC service start output prints before the shell prompt returns, matching the clean output behavior on systemd systems.
